### PR TITLE
Move GetStatus() from Fiks-IO-client to Send-client with models + tests

### DIFF
--- a/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerFixture.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerFixture.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using KS.Fiks.IO.Send.Client.Catalog;
+using KS.Fiks.IO.Send.Client.Configuration;
+using KS.Fiks.IO.Send.Client.Models;
+using Ks.Fiks.Maskinporten.Client;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+
+namespace KS.Fiks.IO.Send.Client.Tests.Catalog;
+
+public class CatalogHandlerFixture
+{
+    public Guid DefaultKontoId = Guid.NewGuid();
+
+    private HttpStatusCode _statusCode = HttpStatusCode.OK;
+    private KatalogKonto _katalogKonto;
+    private KontoSvarStatus _status;
+    private KontoOffentligNokkel _kontoOffentligNokkel;
+    private string _scheme = "http";
+    private string _host = "api.fiks.dev.ks";
+    private int _port = 80;
+    private string _path = "/svarinn2/katalog/api/v1";
+    private string _accessToken = "token";
+    private string _integrasjonPassword = "default";
+    private Guid _integrasjonId;
+
+    public CatalogHandlerFixture()
+    {
+        HttpMessageHandleMock = new Mock<HttpMessageHandler>();
+        MaskinportenClientMock = new Mock<IMaskinportenClient>();
+        SetDefaultValues();
+    }
+
+    internal CatalogHandler CreateSut()
+    {
+        SetupMocks();
+        return new CatalogHandler(
+            new KatalogConfiguration(_path, _scheme, _host, _port),
+            new IntegrasjonConfiguration(_integrasjonId, _integrasjonPassword),
+            MaskinportenClientMock.Object,
+            new HttpClient(HttpMessageHandleMock.Object));
+    }
+
+    public Mock<HttpMessageHandler> HttpMessageHandleMock { get; }
+
+    public Mock<IMaskinportenClient> MaskinportenClientMock { get; }
+
+    public LookupRequest DefaultLookupRequest => new LookupRequest(
+        "defaultIdentifier",
+        "defaultMessageType",
+        0);
+
+    public CatalogHandlerFixture WithStatusCode(HttpStatusCode code)
+    {
+        _statusCode = code;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithAccountResponse(KatalogKonto response)
+    {
+        _katalogKonto = response;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithStatusResponse(KontoSvarStatus response)
+    {
+        _status = response;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithPublicKeyResponse(KontoOffentligNokkel response)
+    {
+        _kontoOffentligNokkel = response;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithScheme(string scheme)
+    {
+        _scheme = scheme;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithHost(string host)
+    {
+        _host = host;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithPort(int port)
+    {
+        _port = port;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithPath(string path)
+    {
+        _path = path;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithAccessToken(string token)
+    {
+        _accessToken = token;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithIntegrasjonId(Guid id)
+    {
+        _integrasjonId = id;
+        return this;
+    }
+
+    public CatalogHandlerFixture WithIntegrasjonPassword(string password)
+    {
+        _integrasjonPassword = password;
+        return this;
+    }
+
+    public KontoOffentligNokkel CreateDefaultPublicKey()
+    {
+        return new KontoOffentligNokkel
+        {
+            IssuerDN = "C=AU",
+            Nokkel = "-----BEGIN CERTIFICATE-----\n"+
+                     "MIICLDCCAdKgAwIBAgIBADAKBggqhkjOPQQDAjB9MQswCQYDVQQGEwJCRTEPMA0G\n"+
+                     "A1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2VydGlmaWNhdGUgYXV0aG9y\n"+
+                     "aXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdudVRMUyBjZXJ0aWZpY2F0\n"+
+                     "ZSBhdXRob3JpdHkwHhcNMTEwNTIzMjAzODIxWhcNMTIxMjIyMDc0MTUxWjB9MQsw\n"+
+                     "CQYDVQQGEwJCRTEPMA0GA1UEChMGR251VExTMSUwIwYDVQQLExxHbnVUTFMgY2Vy\n"+
+                     "dGlmaWNhdGUgYXV0aG9yaXR5MQ8wDQYDVQQIEwZMZXV2ZW4xJTAjBgNVBAMTHEdu\n"+
+                     "dVRMUyBjZXJ0aWZpY2F0ZSBhdXRob3JpdHkwWTATBgcqhkjOPQIBBggqhkjOPQMB\n"+
+                     "BwNCAARS2I0jiuNn14Y2sSALCX3IybqiIJUvxUpj+oNfzngvj/Niyv2394BWnW4X\n"+
+                     "uQ4RTEiywK87WRcWMGgJB5kX/t2no0MwQTAPBgNVHRMBAf8EBTADAQH/MA8GA1Ud\n"+
+                     "DwEB/wQFAwMHBgAwHQYDVR0OBBYEFPC0gf6YEr+1KLlkQAPLzB9mTigDMAoGCCqG\n"+
+                     "SM49BAMCA0gAMEUCIDGuwD1KPyG+hRf88MeyMQcqOFZD0TbVleF+UsAGQ4enAiEA\n"+
+                     "l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=\n"+
+                     "-----END CERTIFICATE-----",
+            Serial = "500",
+            SubjectDN = "C=AU",
+            ValidFrom = DateTime.Now,
+            ValidTo = DateTime.Now.Add(TimeSpan.FromDays(2))
+        };
+    }
+
+    private void SetDefaultValues()
+    {
+        _integrasjonId = Guid.NewGuid();
+    }
+
+    private void SetupMocks()
+    {
+        SetHttpResponse();
+        MaskinportenClientMock.Setup(_ => _.GetAccessToken(It.IsAny<string>()))
+            .ReturnsAsync(new MaskinportenToken(_accessToken, 1000));
+    }
+
+    private void SetHttpResponse()
+    {
+        var responseMessage = new HttpResponseMessage()
+        {
+            StatusCode = _statusCode,
+            Content = GetDefaultContent()
+        };
+
+        HttpMessageHandleMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(responseMessage)
+            .Verifiable();
+    }
+
+    private StringContent GetDefaultContent()
+    {
+        if (_katalogKonto != null)
+        {
+            return new StringContent(JsonConvert.SerializeObject(_katalogKonto));
+        }
+
+        if (_status != null)
+        {
+            return new StringContent(JsonConvert.SerializeObject(_status));
+        }
+
+        if (_kontoOffentligNokkel != null)
+        {
+            return new StringContent(JsonConvert.SerializeObject(_kontoOffentligNokkel));
+        }
+
+        var responseAsJsonString = @"{" +
+                                   "\"fiksOrgId\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"," +
+                                   "\"fiksOrgNavn\": \"string\"," +
+                                   "\"kontoId\": \"3fa85f64-5717-4562-b3fc-2c963f66afa6\"," +
+                                   "\"kontoNavn\": \"string\"," +
+                                   "\"status\": {" +
+                                   "\"gyldigAvsender\": true," +
+                                   "\"gyldigMottaker\": true," +
+                                   "\"melding\": \"string\"" +
+                                   "}" +
+                                   "}";
+        return new StringContent(responseAsJsonString);
+    }
+}

--- a/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using FluentAssertions;
+using KS.Fiks.IO.Send.Client.Exceptions;
+using KS.Fiks.IO.Send.Client.Models;
+using Moq;
+using Moq.Protected;
+using Org.BouncyCastle.X509;
+using Xunit;
+
+namespace KS.Fiks.IO.Send.Client.Tests.Catalog;
+
+public class CatalogHandlerTests
+{
+    private readonly CatalogHandlerFixture _fixture = new();
+
+    [Fact]
+    public async Task GetsExpectedAccount()
+    {
+        var expectedAccount = new KatalogKonto
+        {
+            KontoId = Guid.NewGuid(),
+            KontoNavn = "accountName",
+            FiksOrgId = Guid.NewGuid(),
+            FiksOrgNavn = "orgName",
+            Status = new KontoSvarStatus
+            {
+                Melding = "No melding",
+                GyldigAvsender = true,
+                GyldigMottaker = false,
+                AntallKonsumenter = 3
+            }
+        };
+        var sut = _fixture.WithAccountResponse(expectedAccount).CreateSut();
+
+        var result = await sut.Lookup(_fixture.DefaultLookupRequest).ConfigureAwait(false);
+
+        result.FiksOrgId.Should().Be(expectedAccount.FiksOrgId);
+        result.FiksOrgNavn.Should().Be(expectedAccount.FiksOrgNavn);
+        result.KontoId.Should().Be(expectedAccount.KontoId);
+        result.KontoNavn.Should().Be(expectedAccount.KontoNavn);
+        result.IsGyldigAvsender.Should().Be(expectedAccount.Status.GyldigAvsender);
+        result.IsGyldigMottaker.Should().Be(expectedAccount.Status.GyldigMottaker);
+        result.AntallKonsumenter.Should().Be(expectedAccount.Status.AntallKonsumenter);
+    }
+
+    [Fact]
+    public async Task GetsExpectedStatus()
+    {
+        var expectedStatus = new KontoSvarStatus()
+        {
+            Melding = "No melding",
+            GyldigAvsender = true,
+            GyldigMottaker = false,
+            AntallKonsumenter = 3
+        };
+        var sut = _fixture.WithStatusResponse(expectedStatus).CreateSut();
+
+        var result = await sut.GetStatus(_fixture.DefaultKontoId).ConfigureAwait(false);
+
+        result.IsGyldigAvsender.Should().Be(expectedStatus.GyldigAvsender);
+        result.IsGyldigMottaker.Should().Be(expectedStatus.GyldigMottaker);
+        result.AntallKonsumenter.Should().Be(expectedStatus.AntallKonsumenter);
+        result.Melding.Should().Be(expectedStatus.Melding);
+    }
+
+    [Fact]
+    public async Task CallsExpectedUri()
+    {
+        var host = "api.fiks.dev.ks.no";
+        var port = 443;
+        var scheme = "https";
+        var path = "/svarinn2/katalog/api/v1";
+
+        var sut = _fixture.WithHost(host).WithPort(port).WithScheme(scheme).WithPath(path).CreateSut();
+
+        var result = await sut.Lookup(_fixture.DefaultLookupRequest).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri.Port == port &&
+                req.RequestUri.Host == host &&
+                req.RequestUri.Scheme == scheme &&
+                req.RequestUri.AbsolutePath == path + "/lookup"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetsExpectedAuthorizationHeader()
+    {
+        var expectedToken = Guid.NewGuid().ToString();
+
+        var sut = _fixture.WithAccessToken(expectedToken).CreateSut();
+
+        var result = await sut.Lookup(_fixture.DefaultLookupRequest).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(
+                req =>
+                    req.Headers.Authorization.Parameter == expectedToken &&
+                    req.Headers.Authorization.Scheme == "Bearer"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetsExpectedIntegrasjonIdAndPassword()
+    {
+        var expectedId = Guid.NewGuid();
+        var expectedPassword = "myIntegrasjonPassword";
+
+        var sut = _fixture.WithIntegrasjonId(expectedId).WithIntegrasjonPassword(expectedPassword).CreateSut();
+
+        var result = await sut.Lookup(_fixture.DefaultLookupRequest).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(
+                req =>
+                    req.Headers.GetValues("integrasjonPassord").FirstOrDefault() ==
+                    expectedPassword &&
+                    req.Headers.GetValues("integrasjonId").FirstOrDefault() ==
+                    expectedId.ToString()),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UsesExpectedQueryParams()
+    {
+        var request = new LookupRequest(
+            "testIdentifier",
+            "testMessageType",
+            3);
+
+        var sut = _fixture.CreateSut();
+
+        var result = await sut.Lookup(request).ConfigureAwait(false);
+
+        Func<HttpRequestMessage, string, string> queryFromReq = (req, field) =>
+            HttpUtility.ParseQueryString(req.RequestUri.Query)[field];
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(
+                (req) =>
+                    queryFromReq(req, "identifikator") == request.Identifikator &&
+                    queryFromReq(req, "meldingProtokoll") == request.Meldingsprotokoll &&
+                    int.Parse(queryFromReq(req, "sikkerhetsniva"), CultureInfo.InvariantCulture) == request.Sikkerhetsniva),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.NoContent)]
+    [InlineData(HttpStatusCode.Redirect)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public async Task ThrowsUnexpectedResponseExceptionWhenResponseIsNot200(HttpStatusCode statusCode)
+    {
+        var sut = _fixture.WithStatusCode(statusCode).CreateSut();
+
+        await Assert.ThrowsAsync<FiksIOSendUnexpectedResponseException>(
+                async () => await sut.Lookup(_fixture.DefaultLookupRequest).ConfigureAwait(false))
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task GetPublicKeyUsesGetCallWithExpectedAccount()
+    {
+        var host = "api.fiks.dev.ks.no";
+        var port = 443;
+        var scheme = "https";
+        var path = "/svarinn2/katalog/api/v1";
+
+        var sut = _fixture.WithHost(host).WithPort(port).WithScheme(scheme).WithPath(path)
+            .WithPublicKeyResponse(_fixture.CreateDefaultPublicKey()).CreateSut();
+        var account = Guid.NewGuid();
+        var result = await sut.GetPublicKey(account).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri.Port == port &&
+                req.RequestUri.Host == host &&
+                req.RequestUri.Scheme == scheme &&
+                req.RequestUri.AbsolutePath ==
+                path + "/kontoer/" + account.ToString() + "/offentligNokkel"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetPublicKeyReturnsX509Object()
+    {
+        var sut = _fixture.WithPublicKeyResponse(_fixture.CreateDefaultPublicKey()).CreateSut();
+        var result = await sut.GetPublicKey(Guid.NewGuid()).ConfigureAwait(false);
+        result.Should().BeOfType<X509Certificate>();
+    }
+
+    [Fact]
+    public async Task GetKontoReturnsExpectedAccount()
+    {
+        var expectedAccount = new KatalogKonto
+        {
+            KontoId = Guid.NewGuid(),
+            KontoNavn = "accountName",
+            FiksOrgId = Guid.NewGuid(),
+            FiksOrgNavn = "orgName",
+            Organisasjonsnummer = "123456789",
+            Kommunenummer = "1234",
+            Status = new KontoSvarStatus
+            {
+                Melding = "Melding",
+                GyldigAvsender = true,
+                GyldigMottaker = false,
+                AntallKonsumenter = 9
+            }
+        };
+        var sut = _fixture.WithAccountResponse(expectedAccount).CreateSut();
+
+        var result = await sut.GetKonto(Guid.NewGuid()).ConfigureAwait(true);
+
+        result.FiksOrgId.Should().Be(expectedAccount.FiksOrgId);
+        result.FiksOrgNavn.Should().Be(expectedAccount.FiksOrgNavn);
+        result.Organisasjonsnummer.Should().Be(expectedAccount.Organisasjonsnummer);
+        result.KontoId.Should().Be(expectedAccount.KontoId);
+        result.KontoNavn.Should().Be(expectedAccount.KontoNavn);
+        result.Kommunenummer.Should().Be(expectedAccount.Kommunenummer);
+        result.IsGyldigAvsender.Should().Be(expectedAccount.Status.GyldigAvsender);
+        result.IsGyldigMottaker.Should().Be(expectedAccount.Status.GyldigMottaker);
+        result.AntallKonsumenter.Should().Be(expectedAccount.Status.AntallKonsumenter);
+    }
+}

--- a/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
+++ b/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
@@ -21,6 +21,8 @@ namespace KS.Fiks.IO.Send.Client.Catalog
 
         private const string AccountsEndpoint = "kontoer";
 
+        private const string StatusEndpoint = "status";
+
         private const string IdentifyerQueryName = "identifikator";
 
         private const string MessageProtocolQueryName = "meldingProtokoll";
@@ -57,6 +59,13 @@ namespace KS.Fiks.IO.Send.Client.Catalog
             var requestUri = CreateGetKontoUri(kontoId);
             var responseAsAccount = await GetAsModel<KatalogKonto>(requestUri).ConfigureAwait(false);
             return Konto.FromKatalogModel(responseAsAccount);
+        }
+
+        public async Task<Status> GetStatus(Guid kontoId)
+        {
+            var requestUri = CreateGetKontoStatusUri(kontoId);
+            var responseAsAccount = await GetAsModel<KontoSvarStatus>(requestUri).ConfigureAwait(false);
+            return Status.FromKontoSvarStatusModel(responseAsAccount);
         }
 
         public async Task<X509Certificate> GetPublicKey(Guid receiverAccountId)
@@ -96,6 +105,17 @@ namespace KS.Fiks.IO.Send.Client.Catalog
         private Uri CreateGetKontoUri(Guid kontoId)
         {
             var servicePath = $"{_katalogConfiguration.Path}/{AccountsEndpoint}/{kontoId.ToString()}";
+            return new UriBuilder(
+                    _katalogConfiguration.Scheme,
+                    _katalogConfiguration.Host,
+                    _katalogConfiguration.Port,
+                    servicePath)
+                .Uri;
+        }
+
+        private Uri CreateGetKontoStatusUri(Guid kontoId)
+        {
+            var servicePath = $"{_katalogConfiguration.Path}/{AccountsEndpoint}/{kontoId.ToString()}/{StatusEndpoint}";
             return new UriBuilder(
                     _katalogConfiguration.Scheme,
                     _katalogConfiguration.Host,

--- a/KS.Fiks.IO.Send.Client/Catalog/ICatalogHandler.cs
+++ b/KS.Fiks.IO.Send.Client/Catalog/ICatalogHandler.cs
@@ -12,5 +12,7 @@ namespace KS.Fiks.IO.Send.Client.Catalog
         Task<Konto> GetKonto(Guid kontoId);
 
         Task<X509Certificate> GetPublicKey(Guid receiverAccountId);
+
+        Task<Status> GetStatus(Guid receiverAccountId);
     }
 }

--- a/KS.Fiks.IO.Send.Client/Models/Konto.cs
+++ b/KS.Fiks.IO.Send.Client/Models/Konto.cs
@@ -20,6 +20,8 @@ namespace KS.Fiks.IO.Send.Client.Models
 
         public bool IsGyldigMottaker { get; set; }
 
+        public long AntallKonsumenter { get; set; }
+
         internal static Konto FromKatalogModel(KatalogKonto katalogKonto)
         {
             return new Konto
@@ -31,7 +33,8 @@ namespace KS.Fiks.IO.Send.Client.Models
                 KontoId = katalogKonto.KontoId,
                 KontoNavn = katalogKonto.KontoNavn,
                 IsGyldigAvsender = katalogKonto.Status.GyldigAvsender,
-                IsGyldigMottaker = katalogKonto.Status.GyldigMottaker
+                IsGyldigMottaker = katalogKonto.Status.GyldigMottaker,
+                AntallKonsumenter = katalogKonto.Status.AntallKonsumenter
             };
         }
     }

--- a/KS.Fiks.IO.Send.Client/Models/KontoSvarStatus.cs
+++ b/KS.Fiks.IO.Send.Client/Models/KontoSvarStatus.cs
@@ -10,6 +10,9 @@ namespace KS.Fiks.IO.Send.Client.Models
         [JsonProperty("gyldigMottaker")]
         public bool GyldigMottaker { get; set; }
 
+        [JsonProperty("antallKonsumenter")]
+        public long AntallKonsumenter { get; set; }
+
         [JsonProperty("melding")]
         public string Melding { get; set; }
     }

--- a/KS.Fiks.IO.Send.Client/Models/Status.cs
+++ b/KS.Fiks.IO.Send.Client/Models/Status.cs
@@ -1,0 +1,24 @@
+namespace KS.Fiks.IO.Send.Client.Models
+{
+    public class Status
+    {
+        public bool IsGyldigAvsender { get; set; }
+
+        public bool IsGyldigMottaker { get; set; }
+
+        public long AntallKonsumenter { get; set; }
+
+        public string Melding { get; set; }
+
+        internal static Status FromKontoSvarStatusModel(KontoSvarStatus kontoSvarStatus)
+        {
+            return new Status
+            {
+                IsGyldigAvsender = kontoSvarStatus.GyldigAvsender,
+                IsGyldigMottaker = kontoSvarStatus.GyldigMottaker,
+                AntallKonsumenter = kontoSvarStatus.AntallKonsumenter,
+                Melding = kontoSvarStatus.Melding
+            };
+        }
+    }
+}


### PR DESCRIPTION
Fiks-IO har fått Status-objekt mm. som må flyttes til Send-klienten nå som mye annet har blitt flyttet dit.

Oppdatert eksisterende modeller og CatalogHandler, samt flyttet testene