### PR TITLE
Erstatte fluent assertions

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-      <PackageReference Include="Serilog" Version="4.0.2" />
-      <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+      <PackageReference Include="Serilog" Version="4.2.0" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     </ItemGroup>
 

--- a/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
@@ -6,12 +6,12 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using FluentAssertions;
 using KS.Fiks.IO.Send.Client.Exceptions;
 using KS.Fiks.IO.Send.Client.Models;
 using Moq;
 using Moq.Protected;
 using Org.BouncyCastle.X509;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Send.Client.Tests.Catalog;
@@ -41,13 +41,13 @@ public class CatalogHandlerTests
 
         var result = await sut.Lookup(_fixture.DefaultLookupRequest).ConfigureAwait(false);
 
-        result.FiksOrgId.Should().Be(expectedAccount.FiksOrgId);
-        result.FiksOrgNavn.Should().Be(expectedAccount.FiksOrgNavn);
-        result.KontoId.Should().Be(expectedAccount.KontoId);
-        result.KontoNavn.Should().Be(expectedAccount.KontoNavn);
-        result.IsGyldigAvsender.Should().Be(expectedAccount.Status.GyldigAvsender);
-        result.IsGyldigMottaker.Should().Be(expectedAccount.Status.GyldigMottaker);
-        result.AntallKonsumenter.Should().Be(expectedAccount.Status.AntallKonsumenter);
+        result.FiksOrgId.ShouldBe(expectedAccount.FiksOrgId);
+        result.FiksOrgNavn.ShouldBe(expectedAccount.FiksOrgNavn);
+        result.KontoId.ShouldBe(expectedAccount.KontoId);
+        result.KontoNavn.ShouldBe(expectedAccount.KontoNavn);
+        result.IsGyldigAvsender.ShouldBe(expectedAccount.Status.GyldigAvsender);
+        result.IsGyldigMottaker.ShouldBe(expectedAccount.Status.GyldigMottaker);
+        result.AntallKonsumenter.ShouldBe(expectedAccount.Status.AntallKonsumenter);
     }
 
     [Fact]
@@ -64,10 +64,10 @@ public class CatalogHandlerTests
 
         var result = await sut.GetStatus(_fixture.DefaultKontoId).ConfigureAwait(false);
 
-        result.IsGyldigAvsender.Should().Be(expectedStatus.GyldigAvsender);
-        result.IsGyldigMottaker.Should().Be(expectedStatus.GyldigMottaker);
-        result.AntallKonsumenter.Should().Be(expectedStatus.AntallKonsumenter);
-        result.Melding.Should().Be(expectedStatus.Melding);
+        result.IsGyldigAvsender.ShouldBe(expectedStatus.GyldigAvsender);
+        result.IsGyldigMottaker.ShouldBe(expectedStatus.GyldigMottaker);
+        result.AntallKonsumenter.ShouldBe(expectedStatus.AntallKonsumenter);
+        result.Melding.ShouldBe(expectedStatus.Melding);
     }
 
     [Fact]
@@ -205,7 +205,7 @@ public class CatalogHandlerTests
     {
         var sut = _fixture.WithPublicKeyResponse(_fixture.CreateDefaultPublicKey()).CreateSut();
         var result = await sut.GetPublicKey(Guid.NewGuid()).ConfigureAwait(false);
-        result.Should().BeOfType<X509Certificate>();
+        result.ShouldBeOfType<X509Certificate>();
     }
 
     [Fact]
@@ -231,14 +231,14 @@ public class CatalogHandlerTests
 
         var result = await sut.GetKonto(Guid.NewGuid()).ConfigureAwait(true);
 
-        result.FiksOrgId.Should().Be(expectedAccount.FiksOrgId);
-        result.FiksOrgNavn.Should().Be(expectedAccount.FiksOrgNavn);
-        result.Organisasjonsnummer.Should().Be(expectedAccount.Organisasjonsnummer);
-        result.KontoId.Should().Be(expectedAccount.KontoId);
-        result.KontoNavn.Should().Be(expectedAccount.KontoNavn);
-        result.Kommunenummer.Should().Be(expectedAccount.Kommunenummer);
-        result.IsGyldigAvsender.Should().Be(expectedAccount.Status.GyldigAvsender);
-        result.IsGyldigMottaker.Should().Be(expectedAccount.Status.GyldigMottaker);
-        result.AntallKonsumenter.Should().Be(expectedAccount.Status.AntallKonsumenter);
+        result.FiksOrgId.ShouldBe(expectedAccount.FiksOrgId);
+        result.FiksOrgNavn.ShouldBe(expectedAccount.FiksOrgNavn);
+        result.Organisasjonsnummer.ShouldBe(expectedAccount.Organisasjonsnummer);
+        result.KontoId.ShouldBe(expectedAccount.KontoId);
+        result.KontoNavn.ShouldBe(expectedAccount.KontoNavn);
+        result.Kommunenummer.ShouldBe(expectedAccount.Kommunenummer);
+        result.IsGyldigAvsender.ShouldBe(expectedAccount.Status.GyldigAvsender);
+        result.IsGyldigMottaker.ShouldBe(expectedAccount.Status.GyldigMottaker);
+        result.AntallKonsumenter.ShouldBe(expectedAccount.Status.AntallKonsumenter);
     }
 }

--- a/KS.Fiks.IO.Send.Client.Tests/FiksIOSenderTests.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/FiksIOSenderTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -8,12 +7,12 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using KS.Fiks.IO.Send.Client.Exceptions;
 using KS.Fiks.IO.Send.Client.Models;
 using Moq;
 using Moq.Protected;
 using Newtonsoft.Json;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Send.Client.Tests
@@ -33,7 +32,7 @@ namespace KS.Fiks.IO.Send.Client.Tests
             var sut = _fixture.CreateSut();
             var result = await sut.Send(_fixture.DefaultMessage, new MemoryStream()).ConfigureAwait(false);
 
-            result.Should().BeOfType<SendtMeldingApiModel>();
+            result.ShouldBeOfType<SendtMeldingApiModel>();
         }
 
         [Fact]
@@ -42,7 +41,7 @@ namespace KS.Fiks.IO.Send.Client.Tests
             var sut = _fixture.CreateSut();
             var result = await sut.Send(_fixture.DefaultMessage).ConfigureAwait(false);
 
-            result.Should().BeOfType<SendtMeldingApiModel>();
+            result.ShouldBeOfType<SendtMeldingApiModel>();
         }
 
         [Fact]
@@ -214,13 +213,13 @@ namespace KS.Fiks.IO.Send.Client.Tests
 
             var sut = _fixture.WithReturnValue(expectedResult).CreateSut();
             var result = await sut.Send(_fixture.DefaultMessage, new MemoryStream()).ConfigureAwait(false);
-            result.MeldingId.Should().Be(expectedResult.MeldingId);
-            result.MeldingType.Should().Be(expectedResult.MeldingType);
-            result.AvsenderKontoId.Should().Be(expectedResult.AvsenderKontoId);
-            result.MottakerKontoId.Should().Be(expectedResult.MottakerKontoId);
-            result.Ttl.Should().Be(expectedResult.Ttl);
-            result.DokumentlagerId.Should().Be(expectedResult.DokumentlagerId);
-            result.SvarPaMelding.Should().Be(expectedResult.SvarPaMelding);
+            result.MeldingId.ShouldBe(expectedResult.MeldingId);
+            result.MeldingType.ShouldBe(expectedResult.MeldingType);
+            result.AvsenderKontoId.ShouldBe(expectedResult.AvsenderKontoId);
+            result.MottakerKontoId.ShouldBe(expectedResult.MottakerKontoId);
+            result.Ttl.ShouldBe(expectedResult.Ttl);
+            result.DokumentlagerId.ShouldBe(expectedResult.DokumentlagerId);
+            result.SvarPaMelding.ShouldBe(expectedResult.SvarPaMelding);
         }
 
         [Fact]

--- a/KS.Fiks.IO.Send.Client.Tests/IntegrasjonAuthenticationStrategyTests.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/IntegrasjonAuthenticationStrategyTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Moq;
+using Shouldly;
 using Xunit;
 
 namespace KS.Fiks.IO.Send.Client.Tests
@@ -22,9 +22,9 @@ namespace KS.Fiks.IO.Send.Client.Tests
 
             var headers = await sut.GetAuthorizationHeaders().ConfigureAwait(false);
 
-            headers.ContainsKey("AUTHORIZATION").Should().BeTrue();
-            headers.ContainsKey("IntegrasjonId").Should().BeTrue();
-            headers.ContainsKey("IntegrasjonPassord").Should().BeTrue();
+            headers.ContainsKey("AUTHORIZATION").ShouldBeTrue();
+            headers.ContainsKey("IntegrasjonId").ShouldBeTrue();
+            headers.ContainsKey("IntegrasjonPassord").ShouldBeTrue();
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace KS.Fiks.IO.Send.Client.Tests
             var expectedId = Guid.NewGuid();
             var sut = _fixture.WithIntegrasjonId(expectedId).CreateSut();
             var headers = await sut.GetAuthorizationHeaders().ConfigureAwait(false);
-            headers["IntegrasjonId"].Should().Be(expectedId.ToString());
+            headers["IntegrasjonId"].ShouldBe(expectedId.ToString());
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace KS.Fiks.IO.Send.Client.Tests
             var expectedPassword = "ExpectedPassword";
             var sut = _fixture.WithIntegrasjonPassword(expectedPassword).CreateSut();
             var headers = await sut.GetAuthorizationHeaders().ConfigureAwait(false);
-            headers["IntegrasjonPassord"].Should().Be(expectedPassword);
+            headers["IntegrasjonPassord"].ShouldBe(expectedPassword);
         }
 
         [Fact]

--- a/KS.Fiks.IO.Send.Client.Tests/KS.Fiks.IO.Send.Client.Tests.csproj
+++ b/KS.Fiks.IO.Send.Client.Tests/KS.Fiks.IO.Send.Client.Tests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="Shouldly" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
           <PrivateAssets>all</PrivateAssets>

--- a/KS.Fiks.IO.Send.Client.Tests/KS.Fiks.IO.Send.Client.Tests.csproj
+++ b/KS.Fiks.IO.Send.Client.Tests/KS.Fiks.IO.Send.Client.Tests.csproj
@@ -11,12 +11,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.1" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="Shouldly" Version="4.2.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/KS.Fiks.IO.Send.Client/KS.Fiks.IO.Send.Client.csproj
+++ b/KS.Fiks.IO.Send.Client/KS.Fiks.IO.Send.Client.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="KS.Fiks.IO.Crypto" Version="1.0.4" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="1.1.10" />
+        <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="2.0.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
**Dette er gjort:**
Erstattet Fluent Assertions med Shouldly og oppdatert tester.

Oppdatert følgenden dependencies: 

- Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.11.1 to 17.12.0.
- Bumps Serilog from 4.0.2 to 4.2.0
- Bumps Serilog.Extensions.Logging from 8.0.0 to 9.0.0
- Bumps KS.Fiks.Maskinporten.Client from 1.1.10 to 2.0.1
- Bumps Newtonsoft.Json from 13.0.3 to 13.0.3
- Bumps [xunit](https://github.com/xunit/xunit) from 2.9.2 to 2.9.3.
- Bumps [xunit.runner.visualstudio](https://github.com/xunit/visualstudio.xunit) from 2.8.2 to 3.0.1.
- Bumps [Microsoft.Extensions.Hosting](https://github.com/dotnet/runtime) from 8.0.1 to 9.0.1.

