### PR TITLE
Add CancellationToken support

### DIFF
--- a/KS.Fiks.IO.Send.Client.Tests/FiksIOSenderFixture.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/FiksIOSenderFixture.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using KS.Fiks.IO.Crypto.Configuration;
 using KS.Fiks.IO.Send.Client.Authentication;
 using KS.Fiks.IO.Send.Client.Configuration;
 using KS.Fiks.IO.Send.Client.Models;
@@ -24,33 +26,47 @@ namespace KS.Fiks.IO.Send.Client.Tests
         private string _returnValueAsJson;
         private Dictionary<string, string> _authorizationHeaders;
         private bool _useInvalidReturnValue = false;
+        private IntegrasjonConfiguration _integrasjonConfiguration;
+        private AsiceSigningConfiguration _asiceSigningConfiguration;
 
         public FiksIOSenderFixture()
         {
             SetDefaultValues();
-            AuthenticationStrategyMock = new Mock<IAuthenticationStrategy>();
             HttpMessageHandleMock = new Mock<HttpMessageHandler>();
+            AuthenticationStrategyMock = new Mock<IAuthenticationStrategy>();
         }
 
         public Mock<IAuthenticationStrategy> AuthenticationStrategyMock { get; }
 
         public Mock<HttpMessageHandler> HttpMessageHandleMock { get; }
 
+        public Guid SenderAccountId { get; } = Guid.NewGuid();
+
+        public Guid ReceiverAccountId { get; } = Guid.NewGuid();
+
+        public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
         public MeldingSpesifikasjonApiModel DefaultMessage =>
-            new MeldingSpesifikasjonApiModel(
-                avsenderKontoId: Guid.NewGuid(),
-                mottakerKontoId: Guid.NewGuid(),
+            new(
+                avsenderKontoId: SenderAccountId,
+                mottakerKontoId: ReceiverAccountId,
                 meldingType: "defaultType",
                 ttl: 100,
                 headere: new Dictionary<string, string> {{ "My_Header", "My_Value" }});
 
-        public FiksIOSender CreateSut()
+        public FiksIOSender CreateSut(IAuthenticationStrategy authenticationStrategy = null)
         {
             SetupMocks();
-            var configuration = new FiksIOSenderConfiguration(_path, _scheme, _host, _port);
+            var configuration = new FiksIOSenderConfiguration(
+                _path,
+                _scheme,
+                _host,
+                _port,
+                _asiceSigningConfiguration,
+                _integrasjonConfiguration);
             return new FiksIOSender(
                 configuration,
-                AuthenticationStrategyMock.Object,
+                authenticationStrategy ?? AuthenticationStrategyMock.Object,
                 new HttpClient(HttpMessageHandleMock.Object));
         }
 
@@ -108,6 +124,18 @@ namespace KS.Fiks.IO.Send.Client.Tests
             return this;
         }
 
+        public FiksIOSenderFixture WithAsiceSigningConfiguration(AsiceSigningConfiguration value)
+        {
+            _asiceSigningConfiguration = value;
+            return this;
+        }
+
+        public FiksIOSenderFixture WithIntegrasjonConfiguration(IntegrasjonConfiguration value)
+        {
+            _integrasjonConfiguration = value;
+            return this;
+        }
+
         private static StringContent GenerateInvalidResponse()
         {
             return new StringContent(">DSFSV#%¤DFGHV___XCXV132<>");
@@ -122,6 +150,8 @@ namespace KS.Fiks.IO.Send.Client.Tests
             _statusCode = HttpStatusCode.Accepted;
             _returnValue = new SendtMeldingApiModel();
             _authorizationHeaders = new Dictionary<string, string>();
+            _asiceSigningConfiguration = new AsiceSigningConfiguration(TestHelper.GetDummyCert(TimeProvider));
+            _integrasjonConfiguration = new IntegrasjonConfiguration(Guid.Empty, string.Empty);
         }
 
         private void SetupMocks()
@@ -132,19 +162,33 @@ namespace KS.Fiks.IO.Send.Client.Tests
 
         private void SetHttpResponse()
         {
-            var responseMessage = new HttpResponseMessage()
-            {
-                StatusCode = _statusCode,
-                Content = _useInvalidReturnValue ? GenerateInvalidResponse() : GenerateJsonResponse()
-            };
+            var isPubKeyRequest = new Func<HttpRequestMessage, bool>(req =>
+                req.RequestUri!.AbsoluteUri.Contains("katalog/api/v1", StringComparison.OrdinalIgnoreCase));
 
             HttpMessageHandleMock
                 .Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
-                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.Is<HttpRequestMessage>(req => isPubKeyRequest(req)),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = JsonContent.Create(TestHelper.GetDummyPublicKey(TimeProvider))
+                });
+
+            HttpMessageHandleMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req => !isPubKeyRequest(req)),
                     ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(responseMessage)
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = _statusCode,
+                    Content = _useInvalidReturnValue ? GenerateInvalidResponse() : GenerateJsonResponse()
+                })
                 .Verifiable();
         }
 

--- a/KS.Fiks.IO.Send.Client.Tests/TestHelper.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/TestHelper.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using KS.Fiks.IO.Send.Client.Models;
 
 namespace KS.Fiks.IO.Send.Client.Tests
 {
@@ -36,6 +39,36 @@ namespace KS.Fiks.IO.Send.Client.Tests
             }
 
             throw new Exception($"Could not find header: {name}");
+        }
+
+        public static X509Certificate2 GetDummyCert(TimeProvider timeProvider = null)
+        {
+            timeProvider ??= TimeProvider.System;
+
+            return new CertificateRequest(
+                new X500DistinguishedName("CN=Test"),
+                RSA.Create(),
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1
+            ).CreateSelfSigned(
+                timeProvider.GetUtcNow(),
+                timeProvider.GetUtcNow().AddDays(1)
+            );
+        }
+
+        public static KontoOffentligNokkel GetDummyPublicKey(TimeProvider timeProvider = null)
+        {
+            var cert = GetDummyCert(timeProvider);
+
+            return new KontoOffentligNokkel
+            {
+                IssuerDN = cert.Issuer,
+                Nokkel = cert.ExportCertificatePem(),
+                Serial = cert.SerialNumber,
+                SubjectDN = cert.Subject,
+                ValidFrom = cert.NotBefore,
+                ValidTo = cert.NotAfter
+            };
         }
     }
 }

--- a/KS.Fiks.IO.Send.Client/IFiksIOSender.cs
+++ b/KS.Fiks.IO.Send.Client/IFiksIOSender.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using KS.Fiks.IO.Crypto.Models;
 using KS.Fiks.IO.Send.Client.Models;
@@ -8,12 +9,12 @@ namespace KS.Fiks.IO.Send.Client
 {
     public interface IFiksIOSender
     {
-        Task<SendtMeldingApiModel> SendWithEncryptedData(MeldingSpesifikasjonApiModel metaData, IPayload payload);
+        Task<SendtMeldingApiModel> SendWithEncryptedData(MeldingSpesifikasjonApiModel metaData, IPayload payload, CancellationToken cancellationToken = default);
 
-        Task<SendtMeldingApiModel> SendWithEncryptedData(MeldingSpesifikasjonApiModel metaData, IList<IPayload> payload);
+        Task<SendtMeldingApiModel> SendWithEncryptedData(MeldingSpesifikasjonApiModel metaData, IList<IPayload> payload, CancellationToken cancellationToken = default);
 
-        Task<SendtMeldingApiModel> Send(MeldingSpesifikasjonApiModel metaData, Stream data);
+        Task<SendtMeldingApiModel> Send(MeldingSpesifikasjonApiModel metaData, Stream data, CancellationToken cancellationToken = default);
 
-        Task<SendtMeldingApiModel> Send(MeldingSpesifikasjonApiModel metaData);
+        Task<SendtMeldingApiModel> Send(MeldingSpesifikasjonApiModel metaData, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
## Description
The `FiksIOSender` implementation does not support cancellation tokens, even though it uses `HttpClient` under the hood.

This PR adds tokens and relevant tests. 