### PR TITLE
Netstandard2.0

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
       <PackageReference Include="Serilog" Version="4.2.0" />
-      <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     </ItemGroup>
 

--- a/KS.Fiks.IO.Send.Client/KS.Fiks.IO.Send.Client.csproj
+++ b/KS.Fiks.IO.Send.Client/KS.Fiks.IO.Send.Client.csproj
@@ -20,7 +20,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="KS.Fiks.IO.Crypto" Version="1.0.5-alpha.netstandard20.1" />
+        <PackageReference Include="KS.Fiks.IO.Crypto" Version="1.0.5" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="2.0.2" />

--- a/KS.Fiks.IO.Send.Client/KS.Fiks.IO.Send.Client.csproj
+++ b/KS.Fiks.IO.Send.Client/KS.Fiks.IO.Send.Client.csproj
@@ -13,14 +13,14 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>FIKS</PackageTags>
         <VersionPrefix>2.0.5</VersionPrefix>
-        <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="KS.Fiks.IO.Crypto" Version="1.0.4" />
+        <PackageReference Include="KS.Fiks.IO.Crypto" Version="1.0.5-alpha.netstandard20.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="KS.Fiks.Maskinporten.Client" Version="2.0.2" />

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub issues](https://img.shields.io/github/issues-raw/ks-no/fiks-io-send-client-dotnet.svg)](//github.com/ks-no/fiks-io-send-client-dotnet/issues)
 
 ## About this library
-This is a .NET library compatible with _[.NET Standard 2.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard)_ for sending messages to the Fiks platform. 
+This is a .NET library compatible with _[.NET Standard 2.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard)_  and _[.NET Standard 2.0](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0)_ for sending messages to the Fiks platform. 
 The library provides functionality to send messages to the Fiks platform using the Fiks IO Send API. The library supports sending messages with and without ASiC-E encryption.
 
 ## Getting Started


### PR DESCRIPTION
**Hvorfor er dette gjort?**
Vi er nødt til å støtte netstandard 2.0 i fiks-io klienten dotnet. Noen av konsumentene er på .NET 4.8. Som gjør at vi er nødt til å støtte dette.

**Hva er gjort:**

- La inn støtte for netstandard 2.0. Oppdatert noe kode til å følge netstandard 2.0 (C# 7.3). Readme er også oppdatert.
- Bumpet deps.