### PR TITLE
Add AntallUavhentedeMeldinger property to Konto and related classes

### DIFF
--- a/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
@@ -34,7 +34,8 @@ public class CatalogHandlerTests
                 Melding = "No melding",
                 GyldigAvsender = true,
                 GyldigMottaker = false,
-                AntallKonsumenter = 3
+                AntallKonsumenter = 3,
+                AntallUavhentedeMeldinger = 1
             }
         };
         var sut = _fixture.WithAccountResponse(expectedAccount).CreateSut();
@@ -48,6 +49,7 @@ public class CatalogHandlerTests
         result.IsGyldigAvsender.ShouldBe(expectedAccount.Status.GyldigAvsender);
         result.IsGyldigMottaker.ShouldBe(expectedAccount.Status.GyldigMottaker);
         result.AntallKonsumenter.ShouldBe(expectedAccount.Status.AntallKonsumenter);
+        result.AntallUavhentedeMeldinger.ShouldBe(expectedAccount.Status.AntallUavhentedeMeldinger);
     }
 
     [Fact]
@@ -58,7 +60,8 @@ public class CatalogHandlerTests
             Melding = "No melding",
             GyldigAvsender = true,
             GyldigMottaker = false,
-            AntallKonsumenter = 3
+            AntallKonsumenter = 3,
+            AntallUavhentedeMeldinger = 5
         };
         var sut = _fixture.WithStatusResponse(expectedStatus).CreateSut();
 
@@ -67,6 +70,7 @@ public class CatalogHandlerTests
         result.IsGyldigAvsender.ShouldBe(expectedStatus.GyldigAvsender);
         result.IsGyldigMottaker.ShouldBe(expectedStatus.GyldigMottaker);
         result.AntallKonsumenter.ShouldBe(expectedStatus.AntallKonsumenter);
+        result.AntallUavhentedeMeldinger.ShouldBe(expectedStatus.AntallUavhentedeMeldinger);
         result.Melding.ShouldBe(expectedStatus.Melding);
     }
 
@@ -224,7 +228,8 @@ public class CatalogHandlerTests
                 Melding = "Melding",
                 GyldigAvsender = true,
                 GyldigMottaker = false,
-                AntallKonsumenter = 9
+                AntallKonsumenter = 9,
+                AntallUavhentedeMeldinger = 10
             }
         };
         var sut = _fixture.WithAccountResponse(expectedAccount).CreateSut();
@@ -240,5 +245,6 @@ public class CatalogHandlerTests
         result.IsGyldigAvsender.ShouldBe(expectedAccount.Status.GyldigAvsender);
         result.IsGyldigMottaker.ShouldBe(expectedAccount.Status.GyldigMottaker);
         result.AntallKonsumenter.ShouldBe(expectedAccount.Status.AntallKonsumenter);
+        result.AntallUavhentedeMeldinger.ShouldBe(expectedAccount.Status.AntallUavhentedeMeldinger);
     }
 }

--- a/KS.Fiks.IO.Send.Client/Models/Konto.cs
+++ b/KS.Fiks.IO.Send.Client/Models/Konto.cs
@@ -22,6 +22,8 @@ namespace KS.Fiks.IO.Send.Client.Models
 
         public long AntallKonsumenter { get; set; }
 
+        public long AntallUavhentedeMeldinger { get; set; }
+
         internal static Konto FromKatalogModel(KatalogKonto katalogKonto)
         {
             return new Konto
@@ -34,7 +36,8 @@ namespace KS.Fiks.IO.Send.Client.Models
                 KontoNavn = katalogKonto.KontoNavn,
                 IsGyldigAvsender = katalogKonto.Status.GyldigAvsender,
                 IsGyldigMottaker = katalogKonto.Status.GyldigMottaker,
-                AntallKonsumenter = katalogKonto.Status.AntallKonsumenter
+                AntallKonsumenter = katalogKonto.Status.AntallKonsumenter,
+                AntallUavhentedeMeldinger = katalogKonto.Status.AntallUavhentedeMeldinger
             };
         }
     }

--- a/KS.Fiks.IO.Send.Client/Models/KontoSvarStatus.cs
+++ b/KS.Fiks.IO.Send.Client/Models/KontoSvarStatus.cs
@@ -15,5 +15,8 @@ namespace KS.Fiks.IO.Send.Client.Models
 
         [JsonProperty("melding")]
         public string Melding { get; set; }
+
+        [JsonProperty("antallUavhentedeMeldinger")]
+        public long AntallUavhentedeMeldinger { get; set; }
     }
 }

--- a/KS.Fiks.IO.Send.Client/Models/Status.cs
+++ b/KS.Fiks.IO.Send.Client/Models/Status.cs
@@ -8,6 +8,8 @@ namespace KS.Fiks.IO.Send.Client.Models
 
         public long AntallKonsumenter { get; set; }
 
+        public long AntallUavhentedeMeldinger { get; set; }
+
         public string Melding { get; set; }
 
         internal static Status FromKontoSvarStatusModel(KontoSvarStatus kontoSvarStatus)
@@ -17,7 +19,8 @@ namespace KS.Fiks.IO.Send.Client.Models
                 IsGyldigAvsender = kontoSvarStatus.GyldigAvsender,
                 IsGyldigMottaker = kontoSvarStatus.GyldigMottaker,
                 AntallKonsumenter = kontoSvarStatus.AntallKonsumenter,
-                Melding = kontoSvarStatus.Melding
+                Melding = kontoSvarStatus.Melding,
+                AntallUavhentedeMeldinger = kontoSvarStatus.AntallUavhentedeMeldinger
             };
         }
     }


### PR DESCRIPTION
**Model updates:**

* Added the `AntallUavhentedeMeldinger` property to the `Konto`, `Status`, and `KontoSvarStatus` model classes, including JSON serialization in `KontoSvarStatus`. [[1]](diffhunk://#diff-0ceff5e6d3b467719d698744f2ab82221488a98957699520cb74c0c418103d0eR25-R26) [[2]](diffhunk://#diff-fe2b15ebe8ead0e350a4ddb5dda6e94555ad2a62a226b0d98b44c6d49e75dec9R18-R20) [[3]](diffhunk://#diff-1ed04d7d81c985a33203039484c7ae855195293cc524a6ccce4d36a609d127daR11-R12)

**Mapping logic:**

* Updated the `FromKatalogModel` and `FromKontoSvarStatusModel` methods to map the new `AntallUavhentedeMeldinger` property from the source models. [[1]](diffhunk://#diff-0ceff5e6d3b467719d698744f2ab82221488a98957699520cb74c0c418103d0eL37-R40) [[2]](diffhunk://#diff-1ed04d7d81c985a33203039484c7ae855195293cc524a6ccce4d36a609d127daL20-R23)

**Unit test enhancements:**

* Modified existing unit tests to set and assert the value of `AntallUavhentedeMeldinger` for both account and status responses, ensuring the property is correctly handled throughout the codebase. [[1]](diffhunk://#diff-9f008aec1462d0d096343ce6e3e75aff84e0a87c30a1606705c0e518d2db3326L37-R38) [[2]](diffhunk://#diff-9f008aec1462d0d096343ce6e3e75aff84e0a87c30a1606705c0e518d2db3326R52) [[3]](diffhunk://#diff-9f008aec1462d0d096343ce6e3e75aff84e0a87c30a1606705c0e518d2db3326L61-R64) [[4]](diffhunk://#diff-9f008aec1462d0d096343ce6e3e75aff84e0a87c30a1606705c0e518d2db3326R73) [[5]](diffhunk://#diff-9f008aec1462d0d096343ce6e3e75aff84e0a87c30a1606705c0e518d2db3326L227-R232) [[6]](diffhunk://#diff-9f008aec1462d0d096343ce6e3e75aff84e0a87c30a1606705c0e518d2db3326R248)