### PR TITLE
Added UploadPublicKey method to CatalogHandler

### DIFF
--- a/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
@@ -214,6 +214,41 @@ public class CatalogHandlerTests
     }
 
     [Fact]
+    public async Task GetPublicKeyThrowsPublicKeyNotFoundExceptionWhenCatalogReturns404()
+    {
+        var sut = _fixture.WithStatusCode(HttpStatusCode.NotFound).CreateSut();
+
+        await Assert.ThrowsAsync<FiksIOSendPublicKeyNotFoundException>(
+                async () => await sut.GetPublicKey(Guid.NewGuid()).ConfigureAwait(false))
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task GetPublicKeyThrowsPublicKeyNotFoundExceptionWhenKeyPayloadIsEmpty()
+    {
+        var sut = _fixture
+            .WithPublicKeyResponse(new KontoOffentligNokkel { Nokkel = null })
+            .CreateSut();
+
+        await Assert.ThrowsAsync<FiksIOSendPublicKeyNotFoundException>(
+                async () => await sut.GetPublicKey(Guid.NewGuid()).ConfigureAwait(false))
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task GetPublicKeyThrowsUnexpectedResponseExceptionOnTransientError()
+    {
+        var sut = _fixture.WithStatusCode(HttpStatusCode.InternalServerError).CreateSut();
+
+        var exception = await Assert.ThrowsAsync<FiksIOSendUnexpectedResponseException>(
+                async () => await sut.GetPublicKey(Guid.NewGuid()).ConfigureAwait(false))
+            .ConfigureAwait(false);
+
+        // A transient failure must not be reported as "key not found".
+        exception.ShouldNotBeOfType<FiksIOSendPublicKeyNotFoundException>();
+    }
+
+    [Fact]
     public async Task GetKontoReturnsExpectedAccount()
     {
         var expectedAccount = new KatalogKonto

--- a/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
@@ -3,9 +3,12 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using Moq.Protected;
+using Newtonsoft.Json.Linq;
 using KS.Fiks.IO.Send.Client.Exceptions;
 using KS.Fiks.IO.Send.Client.Models;
 using Moq;
@@ -246,5 +249,124 @@ public class CatalogHandlerTests
         result.IsGyldigMottaker.ShouldBe(expectedAccount.Status.GyldigMottaker);
         result.AntallKonsumenter.ShouldBe(expectedAccount.Status.AntallKonsumenter);
         result.AntallUavhentedeMeldinger.ShouldBe(expectedAccount.Status.AntallUavhentedeMeldinger);
+    }
+
+    [Fact]
+    public async Task UploadPublicKeyCallsPutToExpectedUri()
+    {
+        var host = "api.fiks.dev.ks.no";
+        var port = 443;
+        var scheme = "https";
+        var path = "/svarinn2/katalog/api/v1";
+        var kontoId = Guid.NewGuid();
+
+        var sut = _fixture.WithHost(host).WithPort(port).WithScheme(scheme).WithPath(path).CreateSut();
+
+        await sut.UploadPublicKey(kontoId, "-----BEGIN CERTIFICATE-----\nTESTDATA\n-----END CERTIFICATE-----");
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Method == HttpMethod.Put &&
+                req.RequestUri.Port == port &&
+                req.RequestUri.Host == host &&
+                req.RequestUri.Scheme == scheme &&
+                req.RequestUri.AbsolutePath == path + "/kontoer/" + kontoId + "/offentligNokkel"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadPublicKeySendsExpectedJsonBodyWithNokkel()
+    {
+        const string pemString = "-----BEGIN CERTIFICATE-----\nTESTDATA\n-----END CERTIFICATE-----";
+        string capturedBody = null;
+
+        var sut = _fixture.CreateSut();
+
+        _fixture.HttpMessageHandleMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
+                capturedBody = await req.Content.ReadAsStringAsync())
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent("{}") });
+
+        await sut.UploadPublicKey(Guid.NewGuid(), pemString);
+
+        capturedBody.ShouldNotBeNull();
+        var json = JObject.Parse(capturedBody);
+        json["nokkel"].Value<string>().ShouldBe(pemString);
+    }
+
+    [Fact]
+    public async Task UploadPublicKeySetsExpectedAuthorizationHeader()
+    {
+        var expectedToken = Guid.NewGuid().ToString();
+        var sut = _fixture.WithAccessToken(expectedToken).CreateSut();
+
+        await sut.UploadPublicKey(Guid.NewGuid(), "pem");
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Headers.Authorization.Scheme == "Bearer" &&
+                req.Headers.Authorization.Parameter == expectedToken),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadPublicKeySetsExpectedIntegrasjonHeaders()
+    {
+        var expectedId = Guid.NewGuid();
+        var expectedPassword = "myIntegrasjonPassword";
+        var sut = _fixture.WithIntegrasjonId(expectedId).WithIntegrasjonPassword(expectedPassword).CreateSut();
+
+        await sut.UploadPublicKey(Guid.NewGuid(), "pem");
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Headers.GetValues("integrasjonId").FirstOrDefault() == expectedId.ToString() &&
+                req.Headers.GetValues("integrasjonPassord").FirstOrDefault() == expectedPassword),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UploadPublicKeySetsContentTypeApplicationJson()
+    {
+        string capturedContentType = null;
+
+        var sut = _fixture.CreateSut();
+
+        _fixture.HttpMessageHandleMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                capturedContentType = req.Content.Headers.ContentType.MediaType)
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent("{}") });
+
+        await sut.UploadPublicKey(Guid.NewGuid(), "pem");
+
+        capturedContentType.ShouldBe("application/json");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    public async Task UploadPublicKeyThrowsOnNon2xxResponse(HttpStatusCode statusCode)
+    {
+        var sut = _fixture.WithStatusCode(statusCode).CreateSut();
+
+        await Assert.ThrowsAsync<FiksIOSendUnexpectedResponseException>(
+            () => sut.UploadPublicKey(Guid.NewGuid(), "pem"));
     }
 }

--- a/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
@@ -3,16 +3,14 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using Moq;
 using Moq.Protected;
 using Newtonsoft.Json.Linq;
 using KS.Fiks.IO.Send.Client.Exceptions;
 using KS.Fiks.IO.Send.Client.Models;
-using Moq;
-using Moq.Protected;
 using Org.BouncyCastle.X509;
 using Shouldly;
 using Xunit;
@@ -290,8 +288,8 @@ public class CatalogHandlerTests
                 "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>(async (req, _) =>
-                capturedBody = await req.Content.ReadAsStringAsync())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                capturedBody = req.Content.ReadAsStringAsync().GetAwaiter().GetResult())
             .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent("{}") });
 
         await sut.UploadPublicKey(Guid.NewGuid(), pemString);

--- a/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
+++ b/KS.Fiks.IO.Send.Client.Tests/Catalog/CatalogHandlerTests.cs
@@ -6,11 +6,11 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using KS.Fiks.IO.Send.Client.Exceptions;
+using KS.Fiks.IO.Send.Client.Models;
 using Moq;
 using Moq.Protected;
 using Newtonsoft.Json.Linq;
-using KS.Fiks.IO.Send.Client.Exceptions;
-using KS.Fiks.IO.Send.Client.Models;
 using Org.BouncyCastle.X509;
 using Shouldly;
 using Xunit;
@@ -392,14 +392,55 @@ public class CatalogHandlerTests
     }
 
     [Theory]
-    [InlineData(HttpStatusCode.Unauthorized)]
-    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.BadRequest)]
     [InlineData(HttpStatusCode.InternalServerError)]
-    public async Task UploadPublicKeyThrowsOnNon2xxResponse(HttpStatusCode statusCode)
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task UploadPublicKeyThrowsUnexpectedResponseExceptionOnNon2xxResponse(HttpStatusCode statusCode)
     {
         var sut = _fixture.WithStatusCode(statusCode).CreateSut();
 
         await Assert.ThrowsAsync<FiksIOSendUnexpectedResponseException>(
             () => sut.UploadPublicKey(Guid.NewGuid(), "pem"));
+    }
+
+    [Fact]
+    public async Task UploadPublicKeyThrowsUnauthorizedExceptionOn401()
+    {
+        var sut = _fixture.WithStatusCode(HttpStatusCode.Unauthorized).CreateSut();
+
+        await Assert.ThrowsAsync<FiksIOSendUnauthorizedException>(
+            () => sut.UploadPublicKey(Guid.NewGuid(), "pem"));
+    }
+
+    [Fact]
+    public async Task UploadPublicKeyThrowsUnexpectedResponseExceptionWithAccountInMessageOn404()
+    {
+        var kontoId = Guid.NewGuid();
+        var sut = _fixture.WithStatusCode(HttpStatusCode.NotFound).CreateSut();
+
+        var exception = await Assert.ThrowsAsync<FiksIOSendUnexpectedResponseException>(
+            () => sut.UploadPublicKey(kontoId, "pem"));
+
+        // A 404 means the account itself is missing, not a transient failure.
+        exception.ShouldNotBeOfType<FiksIOSendPublicKeyNotFoundException>();
+        exception.Message.ShouldContain(kontoId.ToString());
+    }
+
+    [Fact]
+    public async Task UploadPublicKeyThrowsArgumentExceptionWhenKontoIdIsEmpty()
+    {
+        var sut = _fixture.CreateSut();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => sut.UploadPublicKey(Guid.Empty, "pem"));
+    }
+
+    [Fact]
+    public async Task GetPublicKeyThrowsArgumentExceptionWhenReceiverAccountIdIsEmpty()
+    {
+        var sut = _fixture.CreateSut();
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => sut.GetPublicKey(Guid.Empty));
     }
 }

--- a/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
+++ b/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
@@ -71,9 +71,33 @@ namespace KS.Fiks.IO.Send.Client.Catalog
         public async Task<X509Certificate> GetPublicKey(Guid receiverAccountId)
         {
             var requestUri = CreatePublicKeyUri(receiverAccountId);
-            var responseAsPublicKeyModel = await GetAsModel<KontoOffentligNokkel>(requestUri, authenticated: false)
-                .ConfigureAwait(false);
-            return X509CertificateReader.ExtractCertificate(responseAsPublicKeyModel.Nokkel);
+
+            // GetPublicKey is unauthenticated, so the request is issued directly here (instead of via
+            // GetAsModel) to special-case HTTP 404 / empty payload as "no key registered" without changing
+            // the shared response handling used by the other catalog endpoints.
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri))
+            {
+                var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
+
+                if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    throw new FiksIOSendPublicKeyNotFoundException(
+                        $"No public key is registered in the catalog for account {receiverAccountId}.");
+                }
+
+                await ThrowIfResponseIsInvalid(response, requestUri).ConfigureAwait(false);
+
+                var responseAsJsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var responseAsPublicKeyModel = JsonConvert.DeserializeObject<KontoOffentligNokkel>(responseAsJsonString);
+
+                if (string.IsNullOrWhiteSpace(responseAsPublicKeyModel?.Nokkel))
+                {
+                    throw new FiksIOSendPublicKeyNotFoundException(
+                        $"No public key is registered in the catalog for account {receiverAccountId}.");
+                }
+
+                return X509CertificateReader.ExtractCertificate(responseAsPublicKeyModel.Nokkel);
+            }
         }
 
         public async Task UploadPublicKey(Guid kontoId, string pemString)

--- a/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
+++ b/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Threading.Tasks;
 using KS.Fiks.Crypto.BouncyCastle;
 using KS.Fiks.IO.Send.Client.Configuration;
@@ -74,6 +75,35 @@ namespace KS.Fiks.IO.Send.Client.Catalog
             var responseAsPublicKeyModel = await GetAsModel<KontoOffentligNokkel>(requestUri, authenticated: false)
                 .ConfigureAwait(false);
             return X509CertificateReader.ExtractCertificate(responseAsPublicKeyModel.Nokkel);
+        }
+
+        public async Task UploadPublicKey(Guid kontoId, string pemString)
+        {
+            var uri = CreatePublicKeyUri(kontoId);
+
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Put, uri))
+            {
+                var accessToken = await _maskinportenClient.GetAccessToken(_integrasjonConfiguration.Scope)
+                    .ConfigureAwait(false);
+
+                requestMessage.Headers.Add("integrasjonId", _integrasjonConfiguration.IntegrasjonId.ToString());
+                requestMessage.Headers.Add("integrasjonPassord", _integrasjonConfiguration.IntegrasjonPassord);
+                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
+
+                requestMessage.Content = new StringContent(
+                    JsonConvert.SerializeObject(new { nokkel = pemString }),
+                    Encoding.UTF8,
+                    "application/json");
+
+                var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw new FiksIOSendUnexpectedResponseException(
+                        $"Got unexpected HTTP Status code {response.StatusCode} from {uri}. Content: {content}.");
+                }
+            }
         }
 
         private static async Task ThrowIfResponseIsInvalid(HttpResponseMessage response, Uri requestUri)

--- a/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
+++ b/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
@@ -70,15 +70,19 @@ namespace KS.Fiks.IO.Send.Client.Catalog
 
         public async Task<X509Certificate> GetPublicKey(Guid receiverAccountId)
         {
+            if (receiverAccountId == Guid.Empty)
+            {
+                throw new ArgumentException("receiverAccountId cannot be empty", nameof(receiverAccountId));
+            }
+
             var requestUri = CreatePublicKeyUri(receiverAccountId);
 
             // GetPublicKey is unauthenticated, so the request is issued directly here (instead of via
             // GetAsModel) to special-case HTTP 404 / empty payload as "no key registered" without changing
             // the shared response handling used by the other catalog endpoints.
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri))
+            using (var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false))
             {
-                var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
-
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
                     throw new FiksIOSendPublicKeyNotFoundException(
@@ -102,6 +106,11 @@ namespace KS.Fiks.IO.Send.Client.Catalog
 
         public async Task UploadPublicKey(Guid kontoId, string pemString)
         {
+            if (kontoId == Guid.Empty)
+            {
+                throw new ArgumentException("kontoId cannot be empty", nameof(kontoId));
+            }
+
             if (string.IsNullOrEmpty(pemString))
             {
                 throw new ArgumentException("pemString cannot be null or empty", nameof(pemString));
@@ -123,6 +132,20 @@ namespace KS.Fiks.IO.Send.Client.Catalog
                     if (!response.IsSuccessStatusCode)
                     {
                         var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                        {
+                            throw new FiksIOSendUnauthorizedException(
+                                $"Unauthorized (HTTP 401) when uploading public key for account {kontoId} to {uri}. " +
+                                $"Check the integration credentials. Content: {content}.");
+                        }
+
+                        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                        {
+                            throw new FiksIOSendUnexpectedResponseException(
+                                $"Account {kontoId} does not exist in the catalog (HTTP 404) at {uri}. Content: {content}.");
+                        }
+
                         throw new FiksIOSendUnexpectedResponseException(
                             $"Got unexpected HTTP Status code {response.StatusCode} from {uri}. Content: {content}.");
                     }
@@ -199,12 +222,13 @@ namespace KS.Fiks.IO.Send.Client.Catalog
                     await AddAuthHeaders(requestMessage).ConfigureAwait(false);
                 }
 
-                var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
+                using (var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false))
+                {
+                    await ThrowIfResponseIsInvalid(response, requestUri).ConfigureAwait(false);
 
-                await ThrowIfResponseIsInvalid(response, requestUri).ConfigureAwait(false);
-
-                var responseAsJsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                return JsonConvert.DeserializeObject<T>(responseAsJsonString);
+                    var responseAsJsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    return JsonConvert.DeserializeObject<T>(responseAsJsonString);
+                }
             }
         }
 

--- a/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
+++ b/KS.Fiks.IO.Send.Client/Catalog/CatalogHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -79,36 +78,37 @@ namespace KS.Fiks.IO.Send.Client.Catalog
 
         public async Task UploadPublicKey(Guid kontoId, string pemString)
         {
+            if (string.IsNullOrEmpty(pemString))
+            {
+                throw new ArgumentException("pemString cannot be null or empty", nameof(pemString));
+            }
+
             var uri = CreatePublicKeyUri(kontoId);
 
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Put, uri))
             {
-                var accessToken = await _maskinportenClient.GetAccessToken(_integrasjonConfiguration.Scope)
-                    .ConfigureAwait(false);
-
-                requestMessage.Headers.Add("integrasjonId", _integrasjonConfiguration.IntegrasjonId.ToString());
-                requestMessage.Headers.Add("integrasjonPassord", _integrasjonConfiguration.IntegrasjonPassord);
-                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
+                await AddAuthHeaders(requestMessage).ConfigureAwait(false);
 
                 requestMessage.Content = new StringContent(
                     JsonConvert.SerializeObject(new { nokkel = pemString }),
                     Encoding.UTF8,
                     "application/json");
 
-                var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
-
-                if (!response.IsSuccessStatusCode)
+                using (var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false))
                 {
-                    var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    throw new FiksIOSendUnexpectedResponseException(
-                        $"Got unexpected HTTP Status code {response.StatusCode} from {uri}. Content: {content}.");
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        throw new FiksIOSendUnexpectedResponseException(
+                            $"Got unexpected HTTP Status code {response.StatusCode} from {uri}. Content: {content}.");
+                    }
                 }
             }
         }
 
         private static async Task ThrowIfResponseIsInvalid(HttpResponseMessage response, Uri requestUri)
         {
-            if (response.StatusCode != HttpStatusCode.OK)
+            if (response.StatusCode != System.Net.HttpStatusCode.OK)
             {
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 throw new FiksIOSendUnexpectedResponseException(
@@ -172,19 +172,7 @@ namespace KS.Fiks.IO.Send.Client.Catalog
             {
                 if (authenticated)
                 {
-                    var accessToken = await _maskinportenClient.GetAccessToken(_integrasjonConfiguration.Scope)
-                        .ConfigureAwait(false);
-
-                    requestMessage.Headers.Add(
-                        "integrasjonId",
-                        _integrasjonConfiguration.IntegrasjonId.ToString());
-
-                    requestMessage.Headers.Add(
-                        "integrasjonPassord",
-                        _integrasjonConfiguration.IntegrasjonPassord);
-
-                    requestMessage.Headers.Authorization =
-                        new AuthenticationHeaderValue("Bearer", accessToken.Token);
+                    await AddAuthHeaders(requestMessage).ConfigureAwait(false);
                 }
 
                 var response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
@@ -194,6 +182,16 @@ namespace KS.Fiks.IO.Send.Client.Catalog
                 var responseAsJsonString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 return JsonConvert.DeserializeObject<T>(responseAsJsonString);
             }
+        }
+
+        private async Task AddAuthHeaders(HttpRequestMessage requestMessage)
+        {
+            var accessToken = await _maskinportenClient.GetAccessToken(_integrasjonConfiguration.Scope)
+                .ConfigureAwait(false);
+
+            requestMessage.Headers.Add("integrasjonId", _integrasjonConfiguration.IntegrasjonId.ToString());
+            requestMessage.Headers.Add("integrasjonPassord", _integrasjonConfiguration.IntegrasjonPassord);
+            requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
         }
     }
 }

--- a/KS.Fiks.IO.Send.Client/Catalog/ICatalogHandler.cs
+++ b/KS.Fiks.IO.Send.Client/Catalog/ICatalogHandler.cs
@@ -15,6 +15,11 @@ namespace KS.Fiks.IO.Send.Client.Catalog
 
         Task<Status> GetStatus(Guid receiverAccountId);
 
+        /// <summary>
+        /// Uploads the public key (PEM) for the given integration account to the Fiks catalog.
+        /// </summary>
+        /// <param name="kontoId">The account ID the key belongs to.</param>
+        /// <param name="pemString">The PEM-encoded public key to upload.</param>
         Task UploadPublicKey(Guid kontoId, string pemString);
     }
 }

--- a/KS.Fiks.IO.Send.Client/Catalog/ICatalogHandler.cs
+++ b/KS.Fiks.IO.Send.Client/Catalog/ICatalogHandler.cs
@@ -14,5 +14,7 @@ namespace KS.Fiks.IO.Send.Client.Catalog
         Task<X509Certificate> GetPublicKey(Guid receiverAccountId);
 
         Task<Status> GetStatus(Guid receiverAccountId);
+
+        Task UploadPublicKey(Guid kontoId, string pemString);
     }
 }

--- a/KS.Fiks.IO.Send.Client/Exceptions/FiksIOSendPublicKeyNotFoundException.cs
+++ b/KS.Fiks.IO.Send.Client/Exceptions/FiksIOSendPublicKeyNotFoundException.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace KS.Fiks.IO.Send.Client.Exceptions
+{
+    /// <summary>
+    /// Thrown by <see cref="Catalog.ICatalogHandler.GetPublicKey"/> when the catalog has no public key
+    /// registered for the requested account (HTTP 404 or an empty key payload). Distinguishes a genuinely
+    /// missing key from a transient catalog failure. Inherits from
+    /// <see cref="FiksIOSendUnexpectedResponseException"/> so existing catch blocks keep working.
+    /// </summary>
+    public class FiksIOSendPublicKeyNotFoundException : FiksIOSendUnexpectedResponseException
+    {
+        public FiksIOSendPublicKeyNotFoundException()
+        {
+        }
+
+        public FiksIOSendPublicKeyNotFoundException(string message)
+            : base(message)
+        {
+        }
+
+        public FiksIOSendPublicKeyNotFoundException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Add UploadPublicKey and distinguish missing key (404) in GetPublicKey

`fiks-io-client-dotnet` is adding automatic public key synchronization on startup — if the configured public key is missing or outdated in the Fiks-IO catalog, the client uploads it automatically. The upload logic belongs in `CatalogHandler` alongside `GetPublicKey`, rather than as a separate class in the higher-level client.

The client also needs to tell "no key registered yet" apart from "catalog temporarily unavailable": the former is safe to upload over, the latter must not trigger a blind upload. Today both surface as the same `FiksIOSendUnexpectedResponseException`, so a dedicated not-found type is introduced.

### Changes

- Added `UploadPublicKey`(Guid kontoId, string pemString) to `ICatalogHandler` and `CatalogHandler`: sends a PUT to `kontoer/{kontoId}/offentligNokkel` with a {"nokkel": "..."} JSON body and Bearer + integrasjon headers. Validates input (kontoId not Guid.Empty, pemString not null/empty → ArgumentException) and maps failures to distinct exceptions: 401 → `FiksIOSendUnauthorizedException` (bad credentials), 404 → `FiksIOSendUnexpectedResponseException` with an account-not-found message, and any other non-2xx → generic `FiksIOSendUnexpectedResponseException`. This lets the automatic sync flow tell why an upload failed.
- Added `FiksIOSendPublicKeyNotFoundException` (subclass of FiksIOSendUnexpectedResponseException, so existing catch blocks keep working)
- `GetPublicKey` now throws FiksIOSendPublicKeyNotFoundException on HTTP 404 and on an empty key payload, letting callers distinguish a missing key from a transient catalog failure. It also validates receiverAccountId against Guid.Empty. The 404 handling is scoped to GetPublicKey only — the shared response handling and the other endpoints (Lookup/GetKonto/GetStatus) are unchanged
- Fixed a resource leak: `GetPublicKey` never disposed its `HttpResponseMessage`, leaking a pooled connection on every call (404, error and happy paths) and risking socket exhaustion under load. The response is now wrapped in using. The same pre-existing leak in the shared GetAsModel helper was fixed as well.
- Added 13 unit tests: 9 for `UploadPublicKey` (HTTP method, URI, request body, auth headers, content type, generic non-2xx error, 401, 404, empty kontoId) and 4 for `GetPublicKey` (404 → not-found, empty payload → not-found, 5xx → generic unexpected-response, empty receiverAccountId → ArgumentException)

Not breaking

- `FiksIOSendPublicKeyNotFoundException` derives from FiksIOSendUnexpectedResponseException, so any existing catch (FiksIOSendUnexpectedResponseException) — including the send path that fetches a recipient's key — still catches it
- The existing 404-on-Lookup test is unaffected (shared response handling untouched)
- Note for upload callers: `FiksIOSendUnauthorizedException` derives from Exception, not from `FiksIOSendUnexpectedResponseException`. A catch (FiksIOSendUnexpectedResponseException) will not catch a 401 from `UploadPublicKey` — handle it with a dedicated catch if needed.